### PR TITLE
Update version string for v0.1.1

### DIFF
--- a/Applications/OpenLIFUApp/slicer-application-properties.cmake
+++ b/Applications/OpenLIFUApp/slicer-application-properties.cmake
@@ -10,7 +10,7 @@ set(VERSION_MINOR
   1
   )
 set(VERSION_PATCH
-  0
+  1
   )
 
 set(DESCRIPTION_SUMMARY


### PR DESCRIPTION
I failed to update this string when creating the release, so I will move the version tag after this is merged