### PR TITLE
Fix database location always being editable upon launch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
  SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/OpenwaterHealth/SlicerOpenLIFU.git
- GIT_TAG        v1.2.0
+ GIT_TAG        076dacf36a397e9f9f22040f1df6f594d5a41cb6
  GIT_PROGRESS   1
  QUIET
  )


### PR DESCRIPTION
Closes #25 

This PR fixes the problem of the database location always being editable due to a database not being connected automatically, which grants superuser privileges.

This should lead the way to a locked-down app experience, though it can be circumvented if a non-admin user (i.e. a non OpenLIFU-admin) deletes all the databases and fallback databases on disk.  It would then ask that user if they want to create a new database as the superuser in that case, but there isn't really a way to solve this in the app, deletion needs to be prevented by the OS.

**Note**: I bumped the version of SlicerOpenLIFU to a version that includes some changes to the Database module. It isn't associated with a SlicerOpenLIFU release yet. If we want all `GIT_TAG`s to associate with a specific release, we'd have to wait to merge this until a new release is made -- but this should be no issue.  If it's fine, we should be able to merge right away and then manually bump the `GIT_TAG` later (as the hash is valid in the history of the main branch of SlicerOpenLIFU)

## For Review

I already tested the cases below. You should just be able to look at the code. However, I don't know if it works on other operating systems so if you have extra time it would be nice to check one or two of the cases below:

1. When the database path is set to a path that is a valid database, the custom app automatically connects a database (and permissions are enforced along with everything else you expect with user account mode on and a valid database connection).

2. When the database path is set to a path that is invalid, but there is a database in the default location (OS-specific, defined in the Database module of SlicerOpenLIFU, see `get_database_destination` if interested), it connects to that.

3. When the database path is set to a path that is invalid, and there is not a database in the default OS-specific location, it asks the user if it wants to create one and then creates the database if they say yes. In that case, the user is a superuser and accounts don't do anything. The workflow controls say "Logged in, proceed to the next step."

    > Maybe if in this superuser state, we shouldn't say "Logged in", we should say "User accounts not enabled, proceed to the next step." or something.

    As soon as the user creates an admin, the app is now 'locked down' and user account mode behaves (you better remember the first password you create!)

4. When the database path is set to a path that is not a database, and there is not a database in the default OS-specific location, it asks the user if it wants to make one. If the user says no, it just opens the app and the user is a superuser but can't do anything because guided mode is enabled and they need a database connection to proceed. Therefore, they must eventually capitulate and make the database by selecting "Load Database", after which it confirms if they want to make the default one.  Everything else works as in (3).

    > Saying "no" to the default situation can be useful if the user doesn't want anything default to be created at all and instead wants to set their own path.