### PR TITLE
Add Qt oneShot to make login banners visible (#33)

### DIFF
--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -127,6 +127,9 @@ class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # For me, even setting this timer to 1ms works! But without a timer it doesn't work.
         qt.QTimer.singleShot(500, lambda : slicer.util.getModuleLogic("OpenLIFUHome").workflow.enforceGuidedModeVisibility(True))
 
+        # Call routine that ends up showing login module banners
+        qt.QTimer.singleShot(1, lambda : slicer.util.getModuleWidget('OpenLIFULogin').onParameterNodeModified(None, None))
+
     def setupNodes(self):
         self.logic.setup3DView()
         self.logic.setupSliceViewers()


### PR DESCRIPTION
Closes #33 

This PR solves the problem in a similar way. 

**Other things tried (and failed):**
1. Adding 'OpenLIFULogin' as a dependency of 'Home'
2. Adding 'OpenLIFULogin' as a dependency of 'Home' and calling `slicer.util.getModuleWidget('OpenLIFULogin').onParameterNodeModified(None, None)` in the Home module `setup()`

## For review

You can check the code or do a test of the app. I was able to see the banners after implementing this.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/00059310-e5bf-43b1-a6d8-a142a61fef8a" />