### PR TITLE
Bump SlicerOpenLIFU to v1.4.0

### DIFF
--- a/Applications/OpenLIFUApp/slicer-application-properties.cmake
+++ b/Applications/OpenLIFUApp/slicer-application-properties.cmake
@@ -10,7 +10,7 @@ set(VERSION_MINOR
   1
   )
 set(VERSION_PATCH
-  3
+  4
   )
 
 set(DESCRIPTION_SUMMARY

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
  SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/OpenwaterHealth/SlicerOpenLIFU.git
- GIT_TAG        v1.3.1
+ GIT_TAG        v1.4.0
  GIT_PROGRESS   1
  QUIET
  )


### PR DESCRIPTION
Closes #39

This also increments the OpenLIFU app version number to 0.1.4 so that we can release v0.1.4 of this app.

For review, see our last version bump and compare the code change: https://github.com/OpenwaterHealth/OpenLIFU-app/pull/35