### PR TITLE
Skip to latest workflow module on startup (#41)

### DIFF
--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -84,6 +84,8 @@ class Home(ScriptedLoadableModule):
 
         slicer.app.connect("startupCompleted()", ensure_database_exists_and_attempt_connect)
 
+        slicer.app.connect("startupCompleted()", lambda : slicer.util.getModuleLogic("OpenLIFUHome").workflow_jump_ahead())
+
 class HomeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py


### PR DESCRIPTION
Closes #41 

After completing startup actions, `workflow_jump_ahead` is called for skipping pre-completed items. In the case that user accounts was not setup, this will skip to the Data module. In the case that user accounts was setup, this will skip to the Login module.

## For review

A code review should be enough.