### PR TITLE
Bump SlicerOpenLIFU to v1.12.0

### DIFF
--- a/Applications/OpenLIFUApp/slicer-application-properties.cmake
+++ b/Applications/OpenLIFUApp/slicer-application-properties.cmake
@@ -7,7 +7,7 @@ set(VERSION_MAJOR
   1
   )
 set(VERSION_MINOR
-  4
+  5
   )
 set(VERSION_PATCH
   0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
  SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/OpenwaterHealth/SlicerOpenLIFU.git
- GIT_TAG        v1.11.0
+ GIT_TAG        v1.12.0
  GIT_PROGRESS   1
  QUIET
  )


### PR DESCRIPTION
This update includes a compatibility update for the OpenLIFU Android app, and a version info display.

We also increment the application version number in preparation to release v1.5.0