### PR TITLE
Bump SlicerOpenLIFU to v1.12.1

### DIFF
--- a/Applications/OpenLIFUApp/slicer-application-properties.cmake
+++ b/Applications/OpenLIFUApp/slicer-application-properties.cmake
@@ -10,7 +10,7 @@ set(VERSION_MINOR
   5
   )
 set(VERSION_PATCH
-  0
+  1
   )
 
 set(DESCRIPTION_SUMMARY

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,7 @@ set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
 FetchContent_Populate(${extension_name}
  SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/OpenwaterHealth/SlicerOpenLIFU.git
- GIT_TAG        v1.12.0
+ GIT_TAG        v1.12.1
  GIT_PROGRESS   1
  QUIET
  )


### PR DESCRIPTION
Application version will be v1.5.1

This update includes support for adding volumes to the OpenLIFU database from DICOM format, and an updated version of the python library openlifu that adds several hardware interface features and a number of fixes.