### PR TITLE
Document our new release process

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,222 @@
+# openlifu-app Release Process
+
+This document describes our release process for the OpenLIFU desktop application.
+
+## Versioning
+
+The desktop application version is defined in:
+
+```text
+Applications/OpenLIFUApp/slicer-application-properties.cmake
+```
+
+Use Git tags of the form:
+
+```text
+vX.Y.Z
+vX.Y.Z-rc.N
+```
+
+`VERSION_MAJOR`, `VERSION_MINOR`, and `VERSION_PATCH` are numeric. Do not put
+`-rc.N` or other suffixes in those fields. A release candidate is identified by
+the Git tag, GitHub prerelease, release component version table row, and package
+filenames.
+
+To visibly distinguish release candidates inside the running application,
+temporarily add an
+`APPLICATION_DISPLAY_NAME` in
+`Applications/OpenLIFUApp/slicer-application-properties.cmake`. For example,
+`v1.12.0-rc.2` could use:
+
+```cmake
+set(APPLICATION_DISPLAY_NAME
+  "OpenLIFU (RC 2)"
+  )
+```
+
+Remove release-candidate display-name decorations before the final release.
+
+Use a new minor version for a planned desktop application release and a patch
+version for fixes to an already released line.
+
+## Branch Model
+
+`main` is the development branch. Release branches are stabilization branches:
+
+```text
+main
+release/1.13
+  v1.13.0-rc.1
+  v1.13.0-rc.2
+  v1.13.0
+  v1.13.1
+```
+
+After a release branch is cut, new feature work continues on `main`. The release
+branch is primarily for stabilization fixes, release-specific updates, and
+SlicerOpenLIFU updates from the selected release line that are needed for the
+desktop application release.
+
+## Planned Cadence
+
+We plan for a biannual desktop application release cadence with an 8-week stabilization window:
+
+```text
+T-8 weeks: dependency-line freeze and release branch
+T-6 weeks: first release candidate
+T-4 weeks: second release candidate, if needed
+T-2 weeks: release-blocker-only changes
+T: final release
+```
+
+The dependency-line freeze means choosing the Slicer version and the
+SlicerOpenLIFU release line (with the `openlifu` compatibility line following from that).
+It does not require freezing the exact SlicerOpenLIFU tag for the whole
+stabilization period. So in other words the major and minor SlicerOpenLIFU versions are frozen,
+but there is room for incorporating bug fixes after the freeze by updating the
+SlicerOpenLIFU patch version.
+
+## T-8 Weeks: Release Branch
+
+1. Choose the target Slicer version.
+2. Choose the SlicerOpenLIFU release line for this desktop application release.
+3. Create the release branch:
+
+   ```bash
+   git checkout main
+   git pull
+   git checkout -b release/X.Y
+   git push -u origin release/X.Y
+   ```
+
+4. Update the SlicerOpenLIFU `GIT_TAG` in the top-level `CMakeLists.txt` to the
+   current tag from that release line.
+5. Confirm the selected SlicerOpenLIFU tag's `openlifu` pin from
+   `OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt` in that tag.
+6. Bump the numeric desktop application version in
+   `Applications/OpenLIFUApp/slicer-application-properties.cmake`.
+7. Commit and push the release-branch setup changes.
+
+## T-6 Weeks: First Release Candidate
+
+1. Update the SlicerOpenLIFU `GIT_TAG` to the intended RC or patch tag from the
+   selected SlicerOpenLIFU release line, if needed.
+2. If the running application should visibly identify this release candidate,
+   set `APPLICATION_DISPLAY_NAME` temporarily (discussed above).
+3. Add the release-candidate row to
+   `docs/release-component-version-table.md`. This script can help generate the
+   row for you, but double check the output:
+
+   ```bash
+   uv run tools/release_component_version_row.py --app-version vX.Y.Z-rc.1
+   ```
+
+4. Commit and push the release-candidate updates.
+5. Make sure all tests pass.
+6. Build the packages.
+7. Rename the packages before uploading them so the filenames include the
+   release-candidate tag, such as `vX.Y.Z-rc.1`.
+8. Tag the release candidate from the release branch:
+
+   ```bash
+   git checkout release/X.Y
+   git pull
+   git tag vX.Y.Z-rc.1
+   git push origin vX.Y.Z-rc.1
+   ```
+
+9. Create the GitHub prerelease from `vX.Y.Z-rc.1` and upload the renamed
+   packages.
+
+## T-4 Weeks: Additional Release Candidates
+
+If another release candidate is needed, repeat the T-6 week flow with the next
+RC tag:
+
+```text
+vX.Y.Z-rc.2
+vX.Y.Z-rc.3
+```
+
+The release branch may take SlicerOpenLIFU RC or patch tags from the selected
+SlicerOpenLIFU release line when they contain fixes needed for this desktop
+application release. Keep the release component version table updated for each
+published release candidate.
+
+## T-2 Weeks: Release Blockers Only
+
+At this point, only release-blocking changes should go into the release branch.
+Allowed changes are:
+
+- Desktop application release blockers.
+- Package or release-documentation fixes.
+- SlicerOpenLIFU RC or patch tags from the selected release line, when they
+  contain fixes needed for this desktop application release.
+
+Avoid new feature work, avoid changing dependency lines, and do not advance the
+SlicerOpenLIFU pin for unrelated fixes.
+
+## T: Final Release
+
+1. Update the SlicerOpenLIFU `GIT_TAG` to the final intended tag from the
+   selected SlicerOpenLIFU release line, if needed.
+2. Remove any release-candidate `APPLICATION_DISPLAY_NAME` decoration unless
+   the final release intentionally needs a distinct display name.
+3. Add the final row to `docs/release-component-version-table.md`:
+
+   ```bash
+   uv run tools/release_component_version_row.py --app-version vX.Y.Z
+   ```
+
+4. Commit and push the final release updates.
+5. Ensure tests pass.
+6. Build the final packages. They should end up with correct names if the desktop application version is just `vX.Y.Z`.
+7. Sign the macOS and Windows packages.
+8. Tag the final release from the release branch:
+
+   ```bash
+   git checkout release/X.Y
+   git pull
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+9. Create the GitHub release from `vX.Y.Z` and upload the packages.
+
+## Patch Releases
+
+Patch releases come from the existing desktop application release branch:
+
+```text
+release/X.Y
+  vX.Y.1
+```
+
+Use patch releases for important fixes to an already released line, package
+fixes, or dependency patch updates needed for the released line.
+
+1. Apply the intended fixes to `release/X.Y`.
+2. Update the SlicerOpenLIFU `GIT_TAG` if the patch release takes a newer
+   SlicerOpenLIFU patch tag for a fix needed by the released line.
+3. Bump the numeric desktop application patch version in
+   `Applications/OpenLIFUApp/slicer-application-properties.cmake`.
+4. Add the patch row to `docs/release-component-version-table.md`:
+
+   ```bash
+   uv run tools/release_component_version_row.py --app-version vX.Y.1
+   ```
+
+5. Commit and push the patch updates.
+6. Ensure tests pass.
+7. Build the packages. They should end up with correct names if the desktop application version is just `vX.Y.Z`.
+8. Sign the macOS and Windows packages.
+9. Tag the patch release from the release branch:
+
+   ```bash
+   git checkout release/X.Y
+   git pull
+   git tag vX.Y.1
+   git push origin vX.Y.1
+   ```
+
+10. Create the GitHub release from `vX.Y.1` and upload the renamed packages.

--- a/docs/release-component-version-table.md
+++ b/docs/release-component-version-table.md
@@ -1,0 +1,31 @@
+# OpenLIFU Release Component Version Table
+
+Use this table to find the component versions used for each OpenLIFU desktop
+application release.
+
+| OpenLIFU app | SlicerOpenLIFU | `openlifu` Python package | 3D Slicer source | Sample database |
+| --- | --- | --- | --- | --- |
+| `v1.12.0+legacy.io` | `v1.19.0+legacy.io` | `v0.20.0+legacy.io.0.9.0` | `868bf4ac` | `openlifu-sample-database: openlifu-v0.20.0` |
+| `v1.12.0` | `v1.19.0` | `v0.20.0` | `868bf4ac` | `openlifu-sample-database: openlifu-v0.20.0` |
+| `v1.11.0` | `v1.18.0` | `v0.18.0` | `868bf4ac` | `DVC: OpenLIFU-python v0.18.0` |
+| `v1.10.0` | `v1.17.0` | `v0.18.0` | `868bf4ac` | `DVC: OpenLIFU-python v0.18.0` |
+| `v1.9.0` | `v1.16.0` | `v0.17.0` | `868bf4ac` | `DVC: OpenLIFU-python v0.14.0` |
+| `v1.8.0` | `v1.15.0` | `v0.15.0` | `868bf4ac` | `DVC: OpenLIFU-python v0.14.0` |
+| `v1.7.0` | `v1.14.0` | `v0.14.0` | `868bf4ac` | `DVC: OpenLIFU-python v0.14.0` |
+| `v1.6.0` | `v1.13.0` | `v0.13.0` | `v5.8.1` | `DVC: OpenLIFU-python v0.13.0` |
+| `v1.5.2` | `v1.12.2` | `v0.12.0` | `v5.8.1` | `DVC: OpenLIFU-python v0.12.0` |
+| `v1.5.1` | `v1.12.1` | `v0.12.0` | `v5.8.1` | `DVC: OpenLIFU-python v0.12.0` |
+| `v1.5.0` | `v1.12.0` | `v0.11.0` | `v5.8.1` | `DVC: OpenLIFU-python v0.11.0` |
+| `v1.4.1` | `v1.11.0` | `v0.11.0` | `v5.8.1` | `DVC: OpenLIFU-python v0.11.0` |
+| `v1.4.0` | `v1.11.0` | `v0.11.0` | `v5.8.1` | `DVC: OpenLIFU-python v0.11.0` |
+| `v1.3.0` | `v1.10.0` | `v0.9.0` | `v5.8.1` | `DVC: OpenLIFU-python v0.9.0` |
+| `v1.2.1` | `v1.9.0` | `v0.8.1` | `v5.8.1` | `DVC: OpenLIFU-python v0.8.1` |
+| `v1.2.0` | `v1.9.0` | `v0.8.1` | `v5.8.1` | `DVC: OpenLIFU-python v0.8.1` |
+| `v1.1.1` | `v1.8.1` | `v0.8.1` | `4c1546f` | `DVC: OpenLIFU-python v0.8.1` |
+| `v1.1.0` | `v1.7.0` | `v0.8.0` | `4c1546f` | `DVC: OpenLIFU-python v0.8.0` |
+| `v1.0.0` | `v1.6.2` | `v0.7.1` | `4c1546f` | `DVC: OpenLIFU-python v0.7.1` |
+| `v0.1.4` | `v1.4.0` | `v0.4.0` | `4c1546f` | `DVC: OpenLIFU-python v0.4.0` |
+| `v0.1.3` | `v1.3.1` | `v0.3.1` | `4c1546f` | `DVC: OpenLIFU-python v0.3.1` |
+| `v0.1.2` | `v1.3.0` | `v0.3.1` | `4c1546f` | `DVC: OpenLIFU-python v0.3.1` |
+| `v0.1.1` | `v1.2.0` | `v0.3.0` | `4c1546f` | `DVC: OpenLIFU-python v0.3.0` |
+| `v0.1.0` | `50a6804b` | `v0.1.0` | `4c1546f` | `DVC: OpenLIFU-python v0.1.0` |

--- a/tools/release_component_version_row.py
+++ b/tools/release_component_version_row.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# ///
+"""Generate one OpenLIFU release component version table row."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+WORKTREE_REF = "WORKTREE"
+APP_PROPERTIES_PATH = "Applications/OpenLIFUApp/slicer-application-properties.cmake"
+SLICEROPENLIFU_REQUIREMENTS_PATH = (
+    "OpenLIFULib/OpenLIFULib/Resources/python-requirements.txt"
+)
+SLICEROPENLIFU_SAMPLE_DATA_PATH = "OpenLIFULib/OpenLIFULib/sample_data.py"
+SLICER_REPOSITORY_URL = "https://github.com/Slicer/Slicer.git"
+
+
+class RowError(RuntimeError):
+    pass
+
+
+def run_git(repo: Path, *args: str) -> str:
+    command = ["git", "-C", str(repo), *args]
+    result = subprocess.run(command, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RowError(f"git command failed: {' '.join(command)}\n{detail}")
+    return result.stdout
+
+
+def read_repo_file(repo: Path, ref: str, path: str) -> str:
+    if ref == WORKTREE_REF:
+        file_path = repo / path
+        try:
+            return file_path.read_text(encoding="utf-8")
+        except FileNotFoundError as exc:
+            raise RowError(f"file not found: {file_path}") from exc
+
+    try:
+        return run_git(repo, "show", f"{ref}:{path}")
+    except RowError as exc:
+        raise RowError(f"could not read {path!r} at {ref!r} in {repo}") from exc
+
+
+def first_cmake_value(text: str, variable_name: str) -> str:
+    pattern = rf"set\s*\(\s*{re.escape(variable_name)}\s+(?P<body>.*?)\)"
+    match = re.search(pattern, text, flags=re.DOTALL)
+    if not match:
+        raise RowError(f"could not find CMake variable {variable_name}")
+    body = re.sub(r"#.*", "", match.group("body"))
+    tokens = [token.strip('"') for token in body.split() if token.strip()]
+    if not tokens:
+        raise RowError(f"CMake variable {variable_name} has no value")
+    return tokens[0]
+
+
+def fetchcontent_git_tag(text: str, block_name: str) -> str:
+    pattern = rf"FetchContent_Populate\s*\(\s*{re.escape(block_name)}(?P<body>.*?)\n\s*\)"
+    match = re.search(pattern, text, flags=re.DOTALL)
+    if not match:
+        raise RowError(f"could not find FetchContent_Populate({block_name})")
+    return git_tag_from_block(match.group("body"), block_name)
+
+
+def sliceropenlifu_git_tag(text: str) -> str:
+    marker = 'set(extension_name "SlicerOpenLIFU")'
+    start = text.find(marker)
+    if start == -1:
+        raise RowError('could not find set(extension_name "SlicerOpenLIFU")')
+    return git_tag_from_block(text[start:], "SlicerOpenLIFU")
+
+
+def git_tag_from_block(text: str, label: str) -> str:
+    match = re.search(r"\bGIT_TAG\s+(?P<tag>[^\s)#]+)", text)
+    if not match:
+        raise RowError(f"could not find GIT_TAG for {label}")
+    return match.group("tag").strip('"')
+
+
+def app_version(app_repo: Path, app_ref: str, override: str | None) -> str:
+    if override:
+        return override
+    if app_ref != WORKTREE_REF and app_ref.startswith("v"):
+        return app_ref
+
+    properties = read_repo_file(app_repo, app_ref, APP_PROPERTIES_PATH)
+    major = first_cmake_value(properties, "VERSION_MAJOR")
+    minor = first_cmake_value(properties, "VERSION_MINOR")
+    patch = first_cmake_value(properties, "VERSION_PATCH")
+    return f"v{major}.{minor}.{patch}"
+
+
+def openlifu_pin(requirements_text: str) -> str:
+    for raw_line in requirements_text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        if line.startswith("git+") and "openlifu-python" in line:
+            tag_match = re.search(r"@(?P<tag>[^#\s]+)", line)
+            if tag_match:
+                return normalize_version(tag_match.group("tag"))
+
+        pin_match = re.match(r"openlifu(?:\[[^\]]+\])?\s*==\s*(?P<pin>\S+)", line)
+        if pin_match:
+            return normalize_version(pin_match.group("pin"))
+
+    raise RowError("could not find an openlifu pin in python-requirements.txt")
+
+
+def normalize_version(version: str) -> str:
+    cleaned = version.strip()
+    if cleaned.startswith("v"):
+        return cleaned
+    if re.match(r"^\d+\.\d+\.\d+(?:[-+].*)?$", cleaned):
+        return f"v{cleaned}"
+    return cleaned
+
+
+def sample_database_from_sliceropenlifu(
+    sliceropenlifu_repo: Path,
+    sliceropenlifu_ref: str,
+) -> str | None:
+    try:
+        sample_data = read_repo_file(
+            sliceropenlifu_repo,
+            sliceropenlifu_ref,
+            SLICEROPENLIFU_SAMPLE_DATA_PATH,
+        )
+    except RowError:
+        return None
+
+    match = re.search(
+        r'^SAMPLE_DATABASE_TAG\s*=\s*["\'](?P<tag>[^"\']+)["\']',
+        sample_data,
+        flags=re.MULTILINE,
+    )
+    if not match:
+        return None
+    return f"openlifu-sample-database: {match.group('tag')}"
+
+
+def sample_database_from_openlifu_readme(openlifu_repo: Path, openlifu_ref: str) -> str | None:
+    for readme_path in ("README.md", "README.rst"):
+        try:
+            readme = read_repo_file(openlifu_repo, openlifu_ref, readme_path)
+        except RowError:
+            continue
+        if "openlifu-sample-database" not in readme:
+            continue
+        match = re.search(
+            r"--branch\s+(?P<tag>\S+)\s+https://github\.com/OpenwaterHealth/openlifu-sample-database",
+            readme,
+        )
+        if match:
+            return f"openlifu-sample-database: {match.group('tag')}"
+    return None
+
+
+def default_sibling_repo(app_repo: Path, *names: str) -> Path | None:
+    for name in names:
+        candidate = app_repo.parent / name
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def existing_repo(path: str | None, label: str) -> Path | None:
+    if path is None:
+        return None
+    repo = Path(path).expanduser().resolve()
+    if not (repo / ".git").exists():
+        raise RowError(f"{label} is not a git repository: {repo}")
+    return repo
+
+
+def generate_row(args: argparse.Namespace) -> str:
+    app_repo = existing_repo(args.app_repo, "app repo")
+    if app_repo is None:
+        app_repo = Path(__file__).resolve().parents[1]
+
+    sliceropenlifu_repo = existing_repo(args.sliceropenlifu_repo, "SlicerOpenLIFU repo")
+    if sliceropenlifu_repo is None:
+        sliceropenlifu_repo = default_sibling_repo(app_repo, "SlicerOpenLIFU")
+    if sliceropenlifu_repo is None:
+        raise RowError("could not find SlicerOpenLIFU repo; pass --sliceropenlifu-repo")
+
+    openlifu_repo = existing_repo(args.openlifu_repo, "OpenLIFU-python repo")
+    if openlifu_repo is None:
+        openlifu_repo = default_sibling_repo(app_repo, "OpenLIFU-python", "openlifu-python")
+
+    cmake = read_repo_file(app_repo, args.app_ref, "CMakeLists.txt")
+    slicer_ref = fetchcontent_git_tag(cmake, "slicersources")
+    sliceropenlifu_ref = sliceropenlifu_git_tag(cmake)
+
+    requirements = read_repo_file(
+        sliceropenlifu_repo,
+        sliceropenlifu_ref,
+        SLICEROPENLIFU_REQUIREMENTS_PATH,
+    )
+    openlifu_ref = openlifu_pin(requirements)
+
+    sample_database = args.sample_database
+    if sample_database is None:
+        sample_database = sample_database_from_sliceropenlifu(
+            sliceropenlifu_repo,
+            sliceropenlifu_ref,
+        )
+    if sample_database is None and openlifu_repo is not None:
+        sample_database = sample_database_from_openlifu_readme(openlifu_repo, openlifu_ref)
+    if sample_database is None:
+        sample_database = "TODO: sample database"
+
+    values = [
+        app_version(app_repo, args.app_ref, args.app_version),
+        short_ref(sliceropenlifu_ref),
+        openlifu_ref,
+        slicer_source_value(slicer_ref),
+        sample_database,
+    ]
+    row = "| " + " | ".join(f"`{value}`" for value in values) + " |"
+
+    if args.header:
+        header = "| OpenLIFU app | SlicerOpenLIFU | `openlifu` Python package | 3D Slicer source | Sample database |"
+        separator = "| --- | --- | --- | --- | --- |"
+        return "\n".join((header, separator, row))
+    return row
+
+
+def short_ref(ref: str) -> str:
+    if re.match(r"^[0-9a-f]{40}$", ref):
+        return ref[:8]
+    return ref
+
+
+def slicer_source_value(ref: str) -> str:
+    if not re.match(r"^[0-9a-f]{40}$", ref):
+        return ref
+
+    tag = slicer_tag_for_commit(ref)
+    if tag:
+        return tag
+    return short_ref(ref)
+
+
+def slicer_tag_for_commit(commit_sha: str) -> str | None:
+    result = subprocess.run(
+        ["git", "ls-remote", "--tags", SLICER_REPOSITORY_URL],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+
+    matching_tags: list[str] = []
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        sha, ref = parts
+        if sha != commit_sha:
+            continue
+        tag_name = ref.removeprefix("refs/tags/").removesuffix("^{}")
+        if re.match(r"^v\d+\.\d+\.", tag_name):
+            matching_tags.append(tag_name)
+
+    if not matching_tags:
+        return None
+    return sorted(matching_tags, key=slicer_tag_sort_key)[-1]
+
+
+def slicer_tag_sort_key(tag_name: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in re.findall(r"\d+", tag_name))
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate one row for docs/release-component-version-table.md.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=f"""Examples:
+  uv run tools/release_component_version_row.py
+  uv run tools/release_component_version_row.py --app-version v1.13.0-rc.1
+  uv run /path/to/OpenLIFU-app/tools/release_component_version_row.py --app-ref v1.12.0
+  uv run tools/release_component_version_row.py --sample-database "openlifu-sample-database: openlifu-v0.21.0"
+
+By default, the script reads the app working tree at:
+  {Path(__file__).resolve().parents[1]}
+
+Use --app-ref to inspect a committed app tag or branch instead.
+""",
+    )
+    parser.add_argument(
+        "--app-ref",
+        default=WORKTREE_REF,
+        help=f"App git ref to inspect. Defaults to {WORKTREE_REF}, meaning the working tree.",
+    )
+    parser.add_argument(
+        "--app-version",
+        help="App version to print, useful for RC tags before they exist.",
+    )
+    parser.add_argument(
+        "--app-repo",
+        help="Path to OpenLIFU-app. Defaults to the repository containing this script.",
+    )
+    parser.add_argument(
+        "--sliceropenlifu-repo",
+        help="Path to SlicerOpenLIFU. Defaults to ../SlicerOpenLIFU next to OpenLIFU-app.",
+    )
+    parser.add_argument(
+        "--openlifu-repo",
+        help="Path to OpenLIFU-python. Defaults to ../OpenLIFU-python next to OpenLIFU-app, if present.",
+    )
+    parser.add_argument(
+        "--sample-database",
+        help="Sample database value to print when it cannot be inferred, or when overriding is clearer.",
+    )
+    parser.add_argument(
+        "--header",
+        action="store_true",
+        help="Print the table header and separator before the row.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        print(generate_row(args))
+    except RowError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
This formalizes the process for bi-annual releases with an 8-week "freeze".

Defining what the "freeze" means is subtle -- that is part of what the document does.

This is a change from how we used to do releases off of the main line!
After this, there will be release branches and release candidates.

This change goes along with the changes to the extension release process in https://github.com/OpenwaterHealth/SlicerOpenLIFU/pull/581, because those are needed to define what kind of bug fixes are expected during the freeze period.