### PR TITLE
Bundle Python environment artifacts (#90)

### DIFF
--- a/Applications/OpenLIFUApp/CMakeLists.txt
+++ b/Applications/OpenLIFUApp/CMakeLists.txt
@@ -98,6 +98,64 @@ slicerMacroBuildApplication(
   ${extra_args}
   )
 
+# --------------------------------------------------------------------------
+# Packaged Python environment inventory
+# --------------------------------------------------------------------------
+
+set(OPENLIFU_PYTHON_ENVIRONMENT_OUTPUT_DIR "${CMAKE_BINARY_DIR}/BuildMetadata")
+set(OPENLIFU_PYTHON_ENVIRONMENT_FILE
+  "${OPENLIFU_PYTHON_ENVIRONMENT_OUTPUT_DIR}/python-environment.txt"
+  )
+set(OPENLIFU_PYTHON_ENVIRONMENT_CMAKE_SCRIPT
+  "${CMAKE_CURRENT_BINARY_DIR}/GeneratePythonEnvironmentArtifacts.cmake"
+  )
+
+file(CONFIGURE
+  OUTPUT "${OPENLIFU_PYTHON_ENVIRONMENT_CMAKE_SCRIPT}"
+  CONTENT [=[
+set(_output_file "@OPENLIFU_PYTHON_ENVIRONMENT_FILE@")
+file(MAKE_DIRECTORY "@OPENLIFU_PYTHON_ENVIRONMENT_OUTPUT_DIR@")
+file(REMOVE "${_output_file}")
+
+execute_process(
+  COMMAND
+    "@PYTHON_EXECUTABLE@" -m pip --disable-pip-version-check
+      list --format=freeze
+  RESULT_VARIABLE _generation_result
+  OUTPUT_FILE "${_output_file}"
+  )
+
+if(NOT _generation_result EQUAL 0)
+  file(REMOVE "${_output_file}")
+  message(FATAL_ERROR
+    "Failed to generate the Python environment inventory "
+    "(result: ${_generation_result})."
+    )
+endif()
+
+message(STATUS "Generated Python environment inventory at ${_output_file}")
+]=]
+  @ONLY
+  NEWLINE_STYLE LF
+  )
+
+add_custom_target(OpenLIFUPythonEnvironmentArtifacts
+  COMMAND "${CMAKE_COMMAND}" -P "${OPENLIFU_PYTHON_ENVIRONMENT_CMAKE_SCRIPT}"
+  BYPRODUCTS "${OPENLIFU_PYTHON_ENVIRONMENT_FILE}"
+  COMMENT "Generating Python environment inventory"
+  VERBATIM
+  )
+
+install(
+  SCRIPT "${OPENLIFU_PYTHON_ENVIRONMENT_CMAKE_SCRIPT}"
+  COMPONENT Runtime
+  )
+install(
+  FILES "${OPENLIFU_PYTHON_ENVIRONMENT_FILE}"
+  DESTINATION "${Slicer_INSTALL_SHARE_DIR}/BuildMetadata"
+  COMPONENT Runtime
+  )
+
 # On Windows, embed the application icon into OpenLIFUApp-real.exe using
 # CTKResEdit as a post-build step, mirroring how the launcher (OpenLIFU.exe)
 # already gets its icon. Without this, Windows populates its icon cache with

--- a/README.md
+++ b/README.md
@@ -34,6 +34,26 @@ Follow [these instructions](https://github.com/OpenwaterHealth/OpenLIFU-python/t
 * [Building on Windows](BUILD_WINDOWS.md)
 * [Building on Linux](BUILD_LINUX.md)
 
+### Packaged Python environment inventory
+
+Packaging records Slicer's Python packages using `pip list --format=freeze` and
+includes the result at
+`share/OpenLIFU-<Slicer version>/BuildMetadata/python-environment.txt`. On Linux,
+this path is inside the package tarball. On Windows, it is under the NSIS
+installation directory, which defaults to
+`%LOCALAPPDATA%\Openwater\OpenLIFU <package version>`.
+
+A normal build does not generate or install this file. To generate a loose copy
+without packaging, build this target in the inner Slicer build:
+
+```sh
+cmake --build <custom-app-superbuild>/Slicer-build \
+  --target OpenLIFUPythonEnvironmentArtifacts
+```
+
+Add `--config Release` on Windows. The loose file is written to
+`<custom-app-superbuild>/Slicer-build/BuildMetadata/python-environment.txt`.
+
 ### Relation to other repositories
 
 * [SlicerOpenLIFU](https://github.com/OpenwaterHealth/SlicerOpenLIFU) is the Slicer extension that drives this Slicer custom application. It can be used as an extension in 3D Slicer.
@@ -49,4 +69,3 @@ So, in order to update the `openlifu` that is used:
 
 
 ![OpenLIFU by Openwater](Applications/OpenLIFUApp/Resources/Images/LogoFull.png?raw=true)
-


### PR DESCRIPTION
This causes a pip-freeze-like text file to be bundled inside any packages that we generate, linux or windows.

For review: feel free to use copilot or the like, otherwise just review the general concept trusting that I tested it on linux.