### PR TITLE
Fix asset download script for openlifu >=0.21.0

### DIFF
--- a/Modules/Scripted/Home/CMakeLists.txt
+++ b/Modules/Scripted/Home/CMakeLists.txt
@@ -29,7 +29,7 @@ slicerMacroBuildScriptedModule(
 set(_download_assets_script "${CMAKE_CURRENT_BINARY_DIR}/openlifu_download_assets.py")
 
 file(WRITE ${_download_assets_script} [==[
-import openlifu
+import openlifu.util.assets
 openlifu.util.assets.download_and_install_modnet()
 openlifu.util.assets.download_and_install_kwave_assets()
 ]==])


### PR DESCRIPTION
openlifu no longer eagerly imports the util subpackage so `import openlifu` no longer exposes
`openlifu.util.assets`, breaking the OpenLIFUDownloadAssets build.

Fixed by importing the submodule explicitly instead.